### PR TITLE
allow preloading legacy oob, generate tk

### DIFF
--- a/features/FEATURE_BLE/ble/generic/GenericSecurityManager.h
+++ b/features/FEATURE_BLE/ble/generic/GenericSecurityManager.h
@@ -433,6 +433,7 @@ private:
         uint8_t attempt_oob:1;
         uint8_t oob_mitm_protection:1;
         uint8_t oob_present:1;
+        uint8_t legacy_pairing_oob_request_pending:1;
     };
 
     pal::SecurityManager &_pal;
@@ -444,6 +445,8 @@ private:
     oob_lesc_value_t _oob_peer_random;
     oob_confirm_t _oob_peer_confirm;
     oob_lesc_value_t _oob_local_random;
+    address_t _oob_temporary_key_creator_address; /**< device which generated and sent the TK */
+    oob_tk_t _oob_temporary_key; /**< used for legacy pairing */
 
     pal::AuthenticationMask _default_authentication;
     pal::KeyDistribution _default_key_distribution;

--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
@@ -563,6 +563,10 @@ ble_error_t GenericSecurityManager::legacyPairingOobReceived(
         _oob_temporary_key = *tk;
         _oob_temporary_key_creator_address = *address;
 
+        if (cb->peer_address == _oob_temporary_key_creator_address) {
+            cb->attempt_oob = true;
+        }
+
         if (cb->legacy_pairing_oob_request_pending) {
             on_legacy_pairing_oob_request(cb->connection);
             /* legacy_pairing_oob_request_pending stops us from

--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
@@ -565,6 +565,10 @@ ble_error_t GenericSecurityManager::legacyPairingOobReceived(
 
         if (cb->legacy_pairing_oob_request_pending) {
             on_legacy_pairing_oob_request(cb->connection);
+            /* legacy_pairing_oob_request_pending stops us from
+             * going into a loop of asking the user for oob
+             * so this reset needs to happen after the call above */
+            cb->legacy_pairing_oob_request_pending = false;
         }
     }
     return BLE_ERROR_NONE;
@@ -720,6 +724,11 @@ void GenericSecurityManager::set_mitm_performed(connection_handle_t connection, 
     ControlBlock_t *cb = get_control_block(connection);
     if (cb) {
         cb->mitm_performed = enable;
+        /* whenever we reset mitm performed we also reset pending requests
+         * as this happens whenever a new pairing attempt happens */
+        if (!enable) {
+            cb->legacy_pairing_oob_request_pending = false;
+        }
     }
 }
 

--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
@@ -513,6 +513,14 @@ ble_error_t GenericSecurityManager::setOOBDataUsage(
     cb->attempt_oob = useOOB;
     cb->oob_mitm_protection = OOBProvidesMITM;
 
+    _oob_temporary_key_creator_address = cb->local_address;
+    get_random_data(_oob_temporary_key.buffer(), 16);
+
+    eventHandler->legacyPairingOobGenerated(
+        &_oob_temporary_key_creator_address,
+        &_oob_temporary_key
+    );
+
     _pal.generate_secure_connections_oob(connection);
 
     return BLE_ERROR_NONE;
@@ -552,7 +560,13 @@ ble_error_t GenericSecurityManager::legacyPairingOobReceived(
             return BLE_ERROR_INVALID_PARAM;
         }
 
-        return _pal.legacy_pairing_oob_request_reply(cb->connection, *tk);
+        _oob_temporary_key = *tk;
+        _oob_peer_address = *address;
+
+        if (cb->legacy_pairing_oob_request_pending) {
+            cb->legacy_pairing_oob_request_pending = false;
+            return _pal.legacy_pairing_oob_request_reply(cb->connection, *tk);
+        }
     }
     return BLE_ERROR_NONE;
 }
@@ -964,7 +978,19 @@ void GenericSecurityManager::on_secure_connections_oob_request(connection_handle
 
 void GenericSecurityManager::on_legacy_pairing_oob_request(connection_handle_t connection) {
     set_mitm_performed(connection);
-    eventHandler->legacyPairingOobRequest(connection);
+
+    ControlBlock_t *cb = get_control_block(connection);
+    if (!cb) {
+        return;
+    }
+
+    if (cb->peer_address == _oob_temporary_key_creator_address
+        || cb->local_address == _oob_temporary_key_creator_address) {
+        _pal.legacy_pairing_oob_request_reply(connection, _oob_temporary_key);
+    } else {
+        cb->legacy_pairing_oob_request_pending = true;
+        eventHandler->legacyPairingOobRequest(connection);
+    }
 }
 
 void GenericSecurityManager::on_secure_connections_oob_generated(
@@ -1135,7 +1161,8 @@ GenericSecurityManager::ControlBlock_t::ControlBlock_t() :
     mitm_performed(false),
     attempt_oob(false),
     oob_mitm_protection(false),
-    oob_present(false) { }
+    oob_present(false),
+    legacy_pairing_oob_request_pending(false) { }
 
 void GenericSecurityManager::on_ltk_request(connection_handle_t connection)
 {


### PR DESCRIPTION
This will handle handing over legacy pairing OOB at any time.
Also adds the hitherto mysteriously missing legacy pairing OOB (temporary key) generation.