### PR TITLE
Fix privacy backward compatibility

### DIFF
--- a/features/FEATURE_BLE/ble/BLE.h
+++ b/features/FEATURE_BLE/ble/BLE.h
@@ -457,9 +457,7 @@ public:
     ble_error_t setAddress(
         BLEProtocol::AddressType_t type,
         const BLEProtocol::AddressBytes_t address
-    ) {
-        return gap().setAddress(type, address);
-    }
+    );
 
     /**
      * Fetch the Bluetooth Low Energy MAC address and type.
@@ -1009,9 +1007,7 @@ public:
     ble_error_t connect(const BLEProtocol::AddressBytes_t  peerAddr,
                         BLEProtocol::AddressType_t         peerAddrType = BLEProtocol::AddressType::RANDOM_STATIC,
                         const Gap::ConnectionParams_t     *connectionParams = NULL,
-                        const GapScanningParams           *scanParams = NULL) {
-        return gap().connect(peerAddr, peerAddrType, connectionParams, scanParams);
-    }
+                        const GapScanningParams           *scanParams = NULL);
 
     /**
      * This call initiates the disconnection procedure, and its completion is
@@ -1045,9 +1041,7 @@ public:
      * connection.
      */
     MBED_DEPRECATED("Use ble.gap().disconnect(...)")
-    ble_error_t disconnect(Gap::DisconnectionReason_t reason) {
-        return gap().disconnect(reason);
-    }
+    ble_error_t disconnect(Gap::DisconnectionReason_t reason);
 
     /**
      * Returns the current Gap state of the device using a bitmask that

--- a/features/FEATURE_BLE/ble/BLEProtocol.h
+++ b/features/FEATURE_BLE/ble/BLEProtocol.h
@@ -87,25 +87,7 @@ namespace BLEProtocol {
              * on RANDOM instead. Use Gap::getRandomAddressType to retrieve the
              * type of the random address.
              */
-            RANDOM_PRIVATE_NON_RESOLVABLE,
-
-            /**
-             * Random address.
-             *
-             * Use Gap::getRandomAddressType to retrieve the type of the random
-             * address.
-             */
-            RANDOM,
-
-            /**
-             * A Public address used as a device identity address.
-             */
-            PUBLIC_IDENTITY,
-
-            /**
-             * A Random static address used as a device identity address.
-             */
-            RANDOM_STATIC_IDENTITY
+            RANDOM_PRIVATE_NON_RESOLVABLE
         };
     };
 

--- a/features/FEATURE_BLE/ble/BLETypes.h
+++ b/features/FEATURE_BLE/ble/BLETypes.h
@@ -564,6 +564,12 @@ struct peer_address_type_t :SafeEnum<peer_address_type_t, uint8_t> {
      */
     peer_address_type_t(type value) :
         SafeEnum<peer_address_type_t, uint8_t>(value) { }
+
+    /**
+     * Default initialization of peer_address_type_t.
+     */
+    peer_address_type_t() :
+        SafeEnum<peer_address_type_t, uint8_t>(PUBLIC) { }
 };
 
 } // namespace ble

--- a/features/FEATURE_BLE/ble/BLETypes.h
+++ b/features/FEATURE_BLE/ble/BLETypes.h
@@ -529,6 +529,43 @@ struct att_security_requirement_t : SafeEnum<att_security_requirement_t, uint8_t
         SafeEnum<att_security_requirement_t, uint8_t>(value) { }
 };
 
+/**
+ * Type that describes a peer device address type.
+ */
+struct peer_address_type_t :SafeEnum<peer_address_type_t, uint8_t> {
+    /** struct scoped enum wrapped by the class */
+    enum type {
+        /**
+         * Public device address.
+         */
+        PUBLIC = 0,
+
+        /**
+         * Random address.
+         *
+         * Use Gap::getRandomAddressType to retrieve the type of the random
+         * address.
+         */
+        RANDOM,
+
+        /**
+         * A Public address used as a device identity address.
+         */
+        PUBLIC_IDENTITY,
+
+        /**
+         * A Random static address used as a device identity address.
+         */
+        RANDOM_STATIC_IDENTITY
+    };
+
+    /**
+     * Construct a new instance of peer_address_type_t.
+     */
+    peer_address_type_t(type value) :
+        SafeEnum<peer_address_type_t, uint8_t>(value) { }
+};
+
 } // namespace ble
 
 /**

--- a/features/FEATURE_BLE/ble/Gap.h
+++ b/features/FEATURE_BLE/ble/Gap.h
@@ -294,9 +294,6 @@ public:
      */
     enum DeprecatedAddressType_t {
         ADDR_TYPE_PUBLIC = BLEProtocol::AddressType::PUBLIC,
-        ADDR_TYPE_RANDOM = BLEProtocol::AddressType::RANDOM,
-        ADDR_TYPE_PUBLIC_IDENTITY = BLEProtocol::AddressType::PUBLIC_IDENTITY,
-        ADDR_TYPE_RANDOM_STATIC_IDENTITY = BLEProtocol::AddressType::RANDOM_STATIC_IDENTITY,
         ADDR_TYPE_RANDOM_STATIC = BLEProtocol::AddressType::RANDOM_STATIC,
         ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE = BLEProtocol::AddressType::RANDOM_PRIVATE_RESOLVABLE,
         ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE = BLEProtocol::AddressType::RANDOM_PRIVATE_NON_RESOLVABLE

--- a/features/FEATURE_BLE/ble/generic/GenericGap.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGap.h
@@ -118,6 +118,16 @@ public:
      */
     virtual ble_error_t connect(
         const BLEProtocol::AddressBytes_t peerAddr,
+        PeerAddressType_t peerAddrType,
+        const ConnectionParams_t *connectionParams,
+        const GapScanningParams *scanParams
+    );
+
+    /**
+     * @see Gap::connect
+     */
+    virtual ble_error_t connect(
+        const BLEProtocol::AddressBytes_t peerAddr,
         BLEProtocol::AddressType_t peerAddrType,
         const ConnectionParams_t *connectionParams,
         const GapScanningParams *scanParams
@@ -295,11 +305,13 @@ public:
     void processConnectionEvent(
         Handle_t handle,
         Role_t role,
-        BLEProtocol::AddressType_t peerAddrType,
+        peer_address_type_t peerAddrType,
         const BLEProtocol::AddressBytes_t peerAddr,
         BLEProtocol::AddressType_t ownAddrType,
         const BLEProtocol::AddressBytes_t ownAddr,
-        const ConnectionParams_t *connectionParams
+        const ConnectionParams_t *connectionParams,
+        const uint8_t *peerResolvableAddr,
+        const uint8_t *localResolvableAddr
     );
 
     /**

--- a/features/FEATURE_BLE/ble/generic/GenericSecurityManager.h
+++ b/features/FEATURE_BLE/ble/generic/GenericSecurityManager.h
@@ -385,8 +385,7 @@ private:
         const BLEProtocol::AddressBytes_t peer_address,
         BLEProtocol::AddressType_t local_address_type,
         const BLEProtocol::AddressBytes_t local_address,
-        const Gap::ConnectionParams_t *connection_params,
-        const BLEProtocol::AddressBytes_t resolved_peer_address
+        const Gap::ConnectionParams_t *connection_params
     );
 
     /**

--- a/features/FEATURE_BLE/ble/generic/GenericSecurityManager.h
+++ b/features/FEATURE_BLE/ble/generic/GenericSecurityManager.h
@@ -381,11 +381,12 @@ private:
     virtual void on_connected(
         connection_handle_t connection,
         Gap::Role_t role,
-        BLEProtocol::AddressType_t peer_address_type,
+        peer_address_type_t peer_address_type,
         const BLEProtocol::AddressBytes_t peer_address,
         BLEProtocol::AddressType_t local_address_type,
         const BLEProtocol::AddressBytes_t local_address,
-        const Gap::ConnectionParams_t *connection_params
+        const Gap::ConnectionParams_t *connection_params,
+        const BLEProtocol::AddressBytes_t resolved_peer_address
     );
 
     /**

--- a/features/FEATURE_BLE/ble/generic/SecurityDb.h
+++ b/features/FEATURE_BLE/ble/generic/SecurityDb.h
@@ -440,7 +440,7 @@ public:
      * @return A handle to the entry.
      */
     virtual entry_handle_t open_entry(
-        BLEProtocol::AddressType_t peer_address_type,
+        peer_address_type_t peer_address_type,
         const address_t &peer_address
     ) {
         entry_handle_t db_handle = find_entry_by_peer_address(peer_address_type, peer_address);
@@ -451,8 +451,8 @@ public:
         SecurityDistributionFlags_t* flags = get_free_entry_flags();
         if (flags) {
             const bool peer_address_public =
-                (peer_address_type == BLEProtocol::AddressType::PUBLIC) ||
-                (peer_address_type == BLEProtocol::AddressType::PUBLIC_IDENTITY);
+                (peer_address_type == peer_address_type_t::PUBLIC) ||
+                (peer_address_type == peer_address_type_t::PUBLIC_IDENTITY);
             /* we need some address to store, so we store even random ones
              * this address will be used as an id, possibly replaced later
              * by identity address */
@@ -473,12 +473,12 @@ public:
      * @return A handle to the entry.
      */
     virtual entry_handle_t find_entry_by_peer_address(
-        BLEProtocol::AddressType_t peer_address_type,
+        peer_address_type_t peer_address_type,
         const address_t &peer_address
     ) {
         const bool peer_address_public =
-            (peer_address_type == BLEProtocol::AddressType::PUBLIC) ||
-            (peer_address_type == BLEProtocol::AddressType::PUBLIC_IDENTITY);
+            (peer_address_type == peer_address_type_t::PUBLIC) ||
+            (peer_address_type == peer_address_type_t::PUBLIC_IDENTITY);
 
         for (size_t i = 0; i < get_entry_count(); i++) {
             entry_handle_t db_handle = get_entry_handle_by_index(i);
@@ -486,7 +486,7 @@ public:
 
             /* only look among disconnected entries */
             if (flags && !flags->connected) {
-                if (peer_address_type == BLEProtocol::AddressType::PUBLIC_IDENTITY &&
+                if (peer_address_type == peer_address_type_t::PUBLIC_IDENTITY &&
                     flags->irk_stored == false) {
                     continue;
                 }
@@ -536,7 +536,7 @@ public:
      * @return A handle to the entry.
      */
     virtual void remove_entry(
-        BLEProtocol::AddressType_t peer_address_type,
+        peer_address_type_t peer_address_type,
         const address_t &peer_address
     ) {
         entry_handle_t db_handle = find_entry_by_peer_address(peer_address_type, peer_address);

--- a/features/FEATURE_BLE/ble/pal/ConnectionEventMonitor.h
+++ b/features/FEATURE_BLE/ble/pal/ConnectionEventMonitor.h
@@ -48,15 +48,18 @@ public:
          * @param[in] local_address_type type of address of the local device.
          * @param[in] local_address Address of the local device that was used during connection.
          * @param[in] connection_params connection parameters like interval, latency and timeout.
+         * @param[in] resolved_peer_address resolved address of the peer; may
+         * be NULL.
          */
         virtual void on_connected(
             connection_handle_t connection,
             ::Gap::Role_t role,
-            BLEProtocol::AddressType_t peer_address_type,
+            ble::peer_address_type_t peer_address_type,
             const BLEProtocol::AddressBytes_t peer_address,
             BLEProtocol::AddressType_t local_address_type,
             const BLEProtocol::AddressBytes_t local_address,
-            const ::Gap::ConnectionParams_t *connection_params
+            const ::Gap::ConnectionParams_t *connection_params,
+            const BLEProtocol::AddressBytes_t resolved_peer_address
         ) = 0;
 
         /**

--- a/features/FEATURE_BLE/ble/pal/ConnectionEventMonitor.h
+++ b/features/FEATURE_BLE/ble/pal/ConnectionEventMonitor.h
@@ -58,8 +58,7 @@ public:
             const BLEProtocol::AddressBytes_t peer_address,
             BLEProtocol::AddressType_t local_address_type,
             const BLEProtocol::AddressBytes_t local_address,
-            const ::Gap::ConnectionParams_t *connection_params,
-            const BLEProtocol::AddressBytes_t resolved_peer_address
+            const ::Gap::ConnectionParams_t *connection_params
         ) = 0;
 
         /**

--- a/features/FEATURE_BLE/ble/pal/GapEvents.h
+++ b/features/FEATURE_BLE/ble/pal/GapEvents.h
@@ -140,7 +140,6 @@ struct GapConnectionCompleteEvent : public GapEvent {
      * @param supervision_timeout Supervision timeout of the connection. It
      * shall be in the range [0x000A : 0x0C80] where a unit represent 10ms.
      *
-     * @note: See Bluetooth 5 Vol 2 PartE: 7.7.65.1 LE Connection Complete Event
      * @note: See Bluetooth 5 Vol 2 PartE: 7.7.65.10 LE Enhanced Connection
      * Complete Event
      */
@@ -158,12 +157,78 @@ struct GapConnectionCompleteEvent : public GapEvent {
         status(status),
         connection_handle(connection_handle),
         role(role),
+        peer_address_type(
+            peer_address_type == advertising_peer_address_type_t::PUBLIC_ADDRESS ?
+                peer_address_type_t::PUBLIC :
+                peer_address_type_t::RANDOM
+        ),
+        peer_address(peer_address),
+        connection_interval(connection_interval),
+        connection_latency(connection_latency),
+        supervision_timeout(supervision_timeout),
+        local_resolvable_private_address(),
+        peer_resolvable_private_address() {
+    }
+
+    /**
+     * Construct a new GapConnectionCompleteEvent.
+     *
+     * @param status Status of the operation: 0x00 in case of success otherwise
+     * the error code associated with the failure.
+     *
+     * @param connection_handle handle of the connection created. This handle
+     * will be used to address the connection in any connection oriented
+     * operation.
+     *
+     * @param role Role of the LE subsystem in the connection.
+     *
+     * @param address_type Type of address used by the peer for this connection.
+     *
+     * @param address Address of the peer used to establish the connection.
+     *
+     * @param connection_interval Connection interval used on this connection.
+     * It shall be in a range [0x0006 : 0x0C80]. A unit is equal to 1.25ms.
+     *
+     * @param connection_latency Number of connection events the slave can
+     * drop.
+     *
+     * @param supervision_timeout Supervision timeout of the connection. It
+     * shall be in the range [0x000A : 0x0C80] where a unit represent 10ms.
+     *
+     * @param local_resolvable_private_address Resolvable private address used
+     * by the local device to establish the connection.
+     *
+     * @param peer_resolvable_private_address Resolvable private address used
+     * by the peer to establish the connection.
+     *
+     * @note: See Bluetooth 5 Vol 2 PartE: 7.7.65.10 LE Enhanced Connection
+     * Complete Event
+     */
+    GapConnectionCompleteEvent(
+        uint8_t status,
+        connection_handle_t connection_handle,
+        connection_role_t role,
+        peer_address_type_t peer_address_type,
+        const address_t& peer_address,
+        uint16_t connection_interval,
+        uint16_t connection_latency,
+        uint16_t supervision_timeout,
+        const address_t& local_resolvable_private_address,
+        const address_t& peer_resolvable_private_address
+    ) :
+        GapEvent(GapEventType::CONNECTION_COMPLETE),
+        status(status),
+        connection_handle(connection_handle),
+        role(role),
         peer_address_type(peer_address_type),
         peer_address(peer_address),
         connection_interval(connection_interval),
         connection_latency(connection_latency),
-        supervision_timeout(supervision_timeout) {
+        supervision_timeout(supervision_timeout),
+        local_resolvable_private_address(local_resolvable_private_address),
+        peer_resolvable_private_address(peer_resolvable_private_address) {
     }
+
 
     /*
      * @param status Indicate if the connection succesfully completed or not:
@@ -188,7 +253,7 @@ struct GapConnectionCompleteEvent : public GapEvent {
     /**
      * Peer address type.
      */
-    const advertising_peer_address_type_t peer_address_type;
+    const peer_address_type_t peer_address_type;
 
     /**
      * Peer address.
@@ -211,6 +276,18 @@ struct GapConnectionCompleteEvent : public GapEvent {
      * It shall be in the range [0x000A : 0x0C80] where a unit represent 10ms.
      */
     const uint16_t supervision_timeout;
+
+    /**
+     * Resolvable private address of the local device.
+     * Set to all 0 if not available.
+     */
+    const address_t local_resolvable_private_address;
+
+    /**
+     * Resolvable private address of the peer.
+     * Set to all 0 if not available.     *
+     */
+    const address_t peer_resolvable_private_address;
 };
 
 

--- a/features/FEATURE_BLE/source/BLE.cpp
+++ b/features/FEATURE_BLE/source/BLE.cpp
@@ -31,6 +31,28 @@
 #include <toolchain.h>
 #endif
 
+#if defined(__GNUC__) && !defined(__CC_ARM)
+#define BLE_DEPRECATED_API_USE_BEGIN \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif defined(__CC_ARM)
+#define BLE_DEPRECATED_API_USE_BEGIN \
+    _Pragma("push") \
+    _Pragma("diag_suppress 1361")
+#else
+#define BLE_DEPRECATED_API_USE_BEGIN
+#endif
+
+#if defined(__GNUC__) && !defined(__CC_ARM)
+#define BLE_DEPRECATED_API_USE_END \
+    _Pragma("GCC diagnostic pop")
+#elif defined(__CC_ARM)
+#define BLE_DEPRECATED_API_USE_END \
+        _Pragma("pop")
+#else
+#define BLE_DEPRECATED_API_USE_BEGIN
+#endif
+
 static const char* error_strings[] = {
     "BLE_ERROR_NONE: No error",
     "BLE_ERROR_BUFFER_OVERFLOW: The requested action would cause a buffer overflow and has been aborted",
@@ -143,14 +165,18 @@ BLE::Instance(InstanceID_t id)
     static BLE *singletons[NUM_INSTANCES];
     if (id < NUM_INSTANCES) {
         if (singletons[id] == NULL) {
+BLE_DEPRECATED_API_USE_BEGIN
             singletons[id] = new BLE(id); /* This object will never be freed. */
+BLE_DEPRECATED_API_USE_END
         }
 
         return *singletons[id];
     }
 
     /* we come here only in the case of a bad interfaceID. */
+BLE_DEPRECATED_API_USE_BEGIN
     static BLE badSingleton(NUM_INSTANCES /* this is a bad index; and will result in a NULL transport. */);
+BLE_DEPRECATED_API_USE_END
     return badSingleton;
 }
 
@@ -161,23 +187,6 @@ void defaultSchedulingCallback(BLE::OnEventsToProcessCallbackContext* params) {
 #else
 #define defaultSchedulingCallback NULL
 #endif
-
-
-BLE::BLE(InstanceID_t instanceIDIn) : instanceID(instanceIDIn), transport(),
-    whenEventsToProcess(defaultSchedulingCallback),
-    event_signaled(false)
-{
-    static BLEInstanceBase *transportInstances[NUM_INSTANCES];
-
-    if (instanceID < NUM_INSTANCES) {
-        if (!transportInstances[instanceID]) {
-            transportInstances[instanceID] = instanceConstructors[instanceID](); /* Call the stack's initializer for the transport object. */
-        }
-        transport = transportInstances[instanceID];
-    } else {
-        transport = NULL;
-    }
-}
 
 bool BLE::hasInitialized(void) const
 {
@@ -332,3 +341,47 @@ void BLE::signalEventsToProcess()
         whenEventsToProcess(&params);
     }
 }
+
+// start of deprecated functions
+
+BLE_DEPRECATED_API_USE_BEGIN
+
+// NOTE: move and remove deprecation once private
+BLE::BLE(InstanceID_t instanceIDIn) : instanceID(instanceIDIn), transport(),
+    whenEventsToProcess(defaultSchedulingCallback),
+    event_signaled(false)
+{
+    static BLEInstanceBase *transportInstances[NUM_INSTANCES];
+
+    if (instanceID < NUM_INSTANCES) {
+        if (!transportInstances[instanceID]) {
+            transportInstances[instanceID] = instanceConstructors[instanceID](); /* Call the stack's initializer for the transport object. */
+        }
+        transport = transportInstances[instanceID];
+    } else {
+        transport = NULL;
+    }
+}
+
+ble_error_t BLE::setAddress(
+    BLEProtocol::AddressType_t type,
+    const BLEProtocol::AddressBytes_t address
+) {
+    return gap().setAddress(type, address);
+}
+
+ble_error_t BLE::connect(
+    const BLEProtocol::AddressBytes_t peerAddr,
+    BLEProtocol::AddressType_t peerAddrType,
+    const Gap::ConnectionParams_t *connectionParams,
+    const GapScanningParams *scanParams
+) {
+    return gap().connect(peerAddr, peerAddrType, connectionParams, scanParams);
+}
+
+ble_error_t BLE::disconnect(Gap::DisconnectionReason_t reason) {
+    return gap().disconnect(reason);
+}
+
+BLE_DEPRECATED_API_USE_END
+

--- a/features/FEATURE_BLE/source/Gap.cpp
+++ b/features/FEATURE_BLE/source/Gap.cpp
@@ -16,6 +16,152 @@
 
 #include "ble/Gap.h"
 
+namespace {
+
+ble_error_t convert_address_type(
+    Gap::PeerAddressType_t input_type,
+    const BLEProtocol::AddressBytes_t address,
+    BLEProtocol::AddressType_t& output_type
+) {
+    typedef Gap::RandomAddressType_t RandomAddressType_t;
+    typedef Gap::PeerAddressType_t PeerAddressType_t;
+    typedef BLEProtocol::AddressType LegacyAddressType_t;
+
+    // best effort; peerAddrTypeIn should not be used when privacy is on.
+    switch(input_type.value()) {
+        case PeerAddressType_t::PUBLIC:
+        case PeerAddressType_t::PUBLIC_IDENTITY:
+            output_type = LegacyAddressType_t::PUBLIC;
+            break;
+        case PeerAddressType_t::RANDOM: {
+            RandomAddressType_t random_address_type(RandomAddressType_t::STATIC);
+            ble_error_t err = Gap::getRandomAddressType(address, &random_address_type);
+            if (err) {
+                return err;
+            }
+            switch (random_address_type.value()) {
+                case RandomAddressType_t::STATIC:
+                    output_type = LegacyAddressType_t::RANDOM_STATIC;
+                    break;
+                case RandomAddressType_t::NON_RESOLVABLE_PRIVATE:
+                    output_type = LegacyAddressType_t::RANDOM_PRIVATE_NON_RESOLVABLE;
+                    break;
+                case RandomAddressType_t::RESOLVABLE_PRIVATE:
+                    output_type = LegacyAddressType_t::RANDOM_PRIVATE_RESOLVABLE;
+                    break;
+            }
+            break;
+        }
+        case PeerAddressType_t::RANDOM_STATIC_IDENTITY:
+            output_type = LegacyAddressType_t::RANDOM_STATIC;
+            break;
+    }
+
+    return BLE_ERROR_NONE;
+}
+
+Gap::PeerAddressType_t convert_legacy_address_type(
+    BLEProtocol::AddressType_t legacy_address
+) {
+    if (legacy_address == BLEProtocol::AddressType::PUBLIC) {
+        return Gap::PeerAddressType_t::PUBLIC;
+    } else {
+        return Gap::PeerAddressType_t::RANDOM;
+    }
+}
+
+}
+
+const Gap::PeripheralPrivacyConfiguration_t Gap::default_peripheral_privacy_configuration = {
+    /* use_non_resolvable_random_address */ false,
+    /* resolution_strategy */ PeripheralPrivacyConfiguration_t::PERFORM_PAIRING_PROCEDURE
+};
+
+const Gap::CentralPrivacyConfiguration_t Gap::default_central_privacy_configuration = {
+    /* use_non_resolvable_random_address */ false,
+    /* resolution_strategy */ CentralPrivacyConfiguration_t::DO_NOT_RESOLVE
+};
+
+void Gap::processConnectionEvent(
+    Handle_t handle,
+    Role_t role,
+    PeerAddressType_t peerAddrType,
+    const BLEProtocol::AddressBytes_t peerAddr,
+    BLEProtocol::AddressType_t ownAddrType,
+    const BLEProtocol::AddressBytes_t ownAddr,
+    const ConnectionParams_t *connectionParams,
+    const uint8_t *peerResolvableAddr,
+    const uint8_t *localResolvableAddr
+) {
+    /* Update Gap state */
+    state.advertising = 0;
+    state.connected   = 1;
+    ++connectionCount;
+
+    ConnectionCallbackParams_t callbackParams(
+        handle,
+        role,
+        peerAddrType,
+        peerAddr,
+        ownAddrType,
+        ownAddr,
+        connectionParams,
+        peerResolvableAddr,
+        localResolvableAddr
+    );
+
+    connectionCallChain.call(&callbackParams);
+}
+
+void Gap::processAdvertisementReport(
+    const BLEProtocol::AddressBytes_t peerAddr,
+    int8_t rssi,
+    bool isScanResponse,
+    GapAdvertisingParams::AdvertisingType_t type,
+    uint8_t advertisingDataLen,
+    const uint8_t *advertisingData,
+    PeerAddressType_t addressType
+) {
+    AdvertisementCallbackParams_t params;
+
+    memcpy(params.peerAddr, peerAddr, ADDR_LEN);
+    params.rssi = rssi;
+    params.isScanResponse = isScanResponse;
+    params.type = type;
+    params.advertisingDataLen = advertisingDataLen;
+    params.advertisingData = advertisingData;
+    params.peerAddrType = addressType;
+
+    convert_address_type(
+        addressType,
+        peerAddr,
+        params.addressType
+    );
+
+    onAdvertisementReport.call(&params);
+}
+
+
+#if defined(__GNUC__) && !defined(__CC_ARM)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__CC_ARM)
+#pragma push
+#pragma diag_suppress 1361
+#endif
+
+Gap::AdvertisementCallbackParams_t::AdvertisementCallbackParams_t() :
+    peerAddr(),
+    rssi(),
+    isScanResponse(),
+    type(),
+    advertisingDataLen(0),
+    advertisingData(NULL),
+    addressType(),
+    peerAddrType(PeerAddressType_t::PUBLIC)
+{
+}
+
 ble_error_t Gap::getRandomAddressType(
     const BLEProtocol::AddressBytes_t address,
     RandomAddressType_t* type
@@ -37,12 +183,162 @@ ble_error_t Gap::getRandomAddressType(
     }
 }
 
-const Gap::PeripheralPrivacyConfiguration_t Gap::default_peripheral_privacy_configuration = {
-    /* use_non_resolvable_random_address */ false,
-    /* resolution_strategy */ PeripheralPrivacyConfiguration_t::PERFORM_PAIRING_PROCEDURE
-};
+Gap::ConnectionCallbackParams_t::ConnectionCallbackParams_t(
+    Handle_t handleIn,
+    Role_t roleIn,
+    BLEProtocol::AddressType_t peerAddrTypeIn,
+    const uint8_t *peerAddrIn,
+    BLEProtocol::AddressType_t ownAddrTypeIn,
+    const uint8_t *ownAddrIn,
+    const ConnectionParams_t *connectionParamsIn,
+    const uint8_t *peerResolvableAddrIn,
+    const uint8_t *localResolvableAddrIn
+) : handle(handleIn),
+    role(roleIn),
+    peerAddrType(peerAddrTypeIn),
+    peerAddr(),
+    ownAddrType(ownAddrTypeIn),
+    ownAddr(),
+    connectionParams(connectionParamsIn),
+    peerResolvableAddr(),
+    localResolvableAddr(),
+    peerAddressType(convert_legacy_address_type(peerAddrTypeIn))
+{
+    constructor_helper(
+        peerAddrIn,
+        ownAddrIn,
+        peerResolvableAddrIn,
+        localResolvableAddrIn
+    );
+}
 
-const Gap::CentralPrivacyConfiguration_t Gap::default_central_privacy_configuration = {
-    /* use_non_resolvable_random_address */ false,
-    /* resolution_strategy */ CentralPrivacyConfiguration_t::DO_NOT_RESOLVE
-};
+Gap::ConnectionCallbackParams_t::ConnectionCallbackParams_t(
+    Handle_t handleIn,
+    Role_t roleIn,
+    PeerAddressType_t peerAddrTypeIn,
+    const uint8_t *peerAddrIn,
+    BLEProtocol::AddressType_t ownAddrTypeIn,
+    const uint8_t *ownAddrIn,
+    const ConnectionParams_t *connectionParamsIn,
+    const uint8_t *peerResolvableAddrIn,
+    const uint8_t *localResolvableAddrIn
+) : handle(handleIn),
+    role(roleIn),
+    peerAddrType(),
+    peerAddr(),
+    ownAddrType(ownAddrTypeIn),
+    ownAddr(),
+    connectionParams(connectionParamsIn),
+    peerResolvableAddr(),
+    localResolvableAddr(),
+    peerAddressType(peerAddrTypeIn)
+{
+    constructor_helper(
+        peerAddrIn,
+        ownAddrIn,
+        peerResolvableAddrIn,
+        localResolvableAddrIn
+    );
+
+    convert_address_type(peerAddrTypeIn, peerAddrIn, peerAddrType);
+}
+
+void Gap::ConnectionCallbackParams_t::constructor_helper(
+    const uint8_t *peerAddrIn,
+    const uint8_t *ownAddrIn,
+    const uint8_t *peerResolvableAddrIn,
+    const uint8_t *localResolvableAddrIn
+) {
+    memcpy(peerAddr, peerAddrIn, ADDR_LEN);
+
+    if (ownAddrIn) {
+        memcpy(ownAddr, ownAddrIn, ADDR_LEN);
+    } else {
+        memset(ownAddr, 0, ADDR_LEN);
+    }
+
+    if (peerResolvableAddrIn) {
+        memcpy(peerResolvableAddr, peerResolvableAddrIn, ADDR_LEN);
+    } else {
+        memset(ownAddr, 0, ADDR_LEN);
+    }
+
+    if (localResolvableAddrIn) {
+        memcpy(localResolvableAddr, localResolvableAddrIn, ADDR_LEN);
+    } else {
+        memset(ownAddr, 0, ADDR_LEN);
+    }
+}
+
+ble_error_t Gap::connect(
+    const BLEProtocol::AddressBytes_t peerAddr,
+    DeprecatedAddressType_t peerAddrType,
+    const ConnectionParams_t *connectionParams,
+    const GapScanningParams *scanParams
+) {
+    return connect(
+        peerAddr,
+        (BLEProtocol::AddressType_t) peerAddrType,
+        connectionParams,
+        scanParams
+    );
+}
+
+void Gap::processConnectionEvent(
+    Handle_t handle,
+    Role_t role,
+    BLEProtocol::AddressType_t peerAddrType,
+    const BLEProtocol::AddressBytes_t peerAddr,
+    BLEProtocol::AddressType_t ownAddrType,
+    const BLEProtocol::AddressBytes_t ownAddr,
+    const ConnectionParams_t *connectionParams,
+    const uint8_t *peerResolvableAddr,
+    const uint8_t *localResolvableAddr
+) {
+    /* Update Gap state */
+    state.advertising = 0;
+    state.connected   = 1;
+    ++connectionCount;
+
+    ConnectionCallbackParams_t callbackParams(
+        handle,
+        role,
+        peerAddrType,
+        peerAddr,
+        ownAddrType,
+        ownAddr,
+        connectionParams,
+        peerResolvableAddr,
+        localResolvableAddr
+    );
+
+    connectionCallChain.call(&callbackParams);
+}
+
+void Gap::processAdvertisementReport(
+    const BLEProtocol::AddressBytes_t peerAddr,
+    int8_t rssi,
+    bool isScanResponse,
+    GapAdvertisingParams::AdvertisingType_t type,
+    uint8_t advertisingDataLen,
+    const uint8_t *advertisingData,
+    BLEProtocol::AddressType_t addressType
+) {
+    AdvertisementCallbackParams_t params;
+    memcpy(params.peerAddr, peerAddr, ADDR_LEN);
+    params.rssi = rssi;
+    params.isScanResponse = isScanResponse;
+    params.type = type;
+    params.advertisingDataLen = advertisingDataLen;
+    params.advertisingData = advertisingData;
+    params.addressType = addressType;
+
+    params.peerAddrType = convert_legacy_address_type(addressType);
+    onAdvertisementReport.call(&params);
+}
+
+#if defined(__GNUC__) && !defined(__CC_ARM)
+#pragma GCC diagnostic pop
+#elif defined(__CC_ARM)
+#pragma pop
+#endif

--- a/features/FEATURE_BLE/source/Gap.cpp
+++ b/features/FEATURE_BLE/source/Gap.cpp
@@ -175,7 +175,7 @@ ble_error_t Gap::getRandomAddressType(
         case 0x00:
             *type = RandomAddressType_t::NON_RESOLVABLE_PRIVATE;
             return BLE_ERROR_NONE;
-        case 0x02:
+        case 0x01:
             *type = RandomAddressType_t::RESOLVABLE_PRIVATE;
             return BLE_ERROR_NONE;
         default:

--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
@@ -968,8 +968,7 @@ void GenericSecurityManager::on_connected(
     const BLEProtocol::AddressBytes_t peer_address,
     BLEProtocol::AddressType_t local_address_type,
     const BLEProtocol::AddressBytes_t local_address,
-    const Gap::ConnectionParams_t *connection_params,
-    const BLEProtocol::AddressBytes_t resolved_peer_address
+    const Gap::ConnectionParams_t *connection_params
 ) {
     MBED_ASSERT(_db);
     ControlBlock_t *cb = acquire_control_block(connection);
@@ -980,11 +979,6 @@ void GenericSecurityManager::on_connected(
     // setup the control block
     cb->local_address = local_address;
     cb->is_master = (role == Gap::CENTRAL);
-
-    // normalize the address
-    if (resolved_peer_address && resolved_peer_address != ble::address_t()) {
-        peer_address = resolved_peer_address;
-    }
 
     // get the associated db handle and the distribution flags if any
     cb->db_entry = _db->open_entry(peer_address_type, peer_address);

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioPalGap.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioPalGap.h
@@ -393,11 +393,13 @@ private:
                 // note the usage of the stack handle, not the HCI handle
                 conn_evt->hdr.param,
                 (connection_role_t::type) conn_evt->role,
-                (advertising_peer_address_type_t::type) conn_evt->addrType,
+                (peer_address_type_t::type) conn_evt->addrType,
                 conn_evt->peerAddr,
                 conn_evt->connInterval,
                 conn_evt->connLatency,
-                conn_evt->supTimeout
+                conn_evt->supTimeout,
+                conn_evt->localRpa,
+                conn_evt->peerRpa
             );
         }
     };

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xCrypto.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xCrypto.cpp
@@ -32,6 +32,8 @@
 #include "mbedtls/entropy.h"
 #include "mbedtls/ecp.h"
 
+#endif
+
 #include "platform/NonCopyable.h"
 #include "platform/CriticalSectionLock.h"
 #include "ble/BLETypes.h"
@@ -45,6 +47,8 @@ namespace ble {
 namespace pal {
 namespace vendor {
 namespace nordic {
+
+#if defined(MBEDTLS_ECDH_C)
 
 CryptoToolbox::CryptoToolbox() : _initialized(false) {
     mbedtls_entropy_init(&_entropy_context);
@@ -131,6 +135,8 @@ bool CryptoToolbox::generate_shared_secret(
     return err ? false : true;
 }
 
+#endif
+
 bool CryptoToolbox::ah(
     const ArrayView<const uint8_t, irk_size_>& irk,
     const ArrayView<const uint8_t, prand_size_>& prand,
@@ -161,6 +167,7 @@ bool CryptoToolbox::ah(
     return true;
 }
 
+#if defined(MBEDTLS_ECDH_C)
 
 void CryptoToolbox::load_mpi(mbedtls_mpi& dest, const ArrayView<const uint8_t, lesc_key_size_>& src) {
     ble::public_key_coord_t src_be = src.data();
@@ -173,6 +180,8 @@ void CryptoToolbox::store_mpi(ArrayView<uint8_t, lesc_key_size_>& dest, const mb
     swap_endian(dest.data(), dest.size());
 }
 
+#endif
+
 void CryptoToolbox::swap_endian(uint8_t* buf, size_t len) {
     for(size_t low = 0, high = (len - 1); high > low; --high, ++low) {
         std::swap(buf[low], buf[high]);
@@ -183,6 +192,3 @@ void CryptoToolbox::swap_endian(uint8_t* buf, size_t len) {
 } // vendor
 } // pal
 } // ble
-
-#endif //defined(MBEDTLS_ECDH_C)
-

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xCrypto.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xCrypto.h
@@ -31,6 +31,8 @@
 #include "mbedtls/entropy.h"
 #include "mbedtls/ecp.h"
 
+#endif
+
 #include "platform/NonCopyable.h"
 #include "ble/BLETypes.h"
 
@@ -64,6 +66,8 @@ public:
      * Size of prand.
      */
     static const ptrdiff_t prand_size_ = 3;
+
+#if defined(MBEDTLS_ECDH_C)
 
     /**
      * Create a new CryptoToolbox.
@@ -105,6 +109,8 @@ public:
         ArrayView<uint8_t, lesc_key_size_> shared_secret
     );
 
+#endif
+
     /**
      * Execute the function ah. This function can be used to generate private
      * resolvable addresses and resolve them.
@@ -118,29 +124,33 @@ public:
      *
      * @return true in case of success and false otherwise.
      */
-    bool ah(
+    static bool ah(
         const ArrayView<const uint8_t, irk_size_>& irk,
         const ArrayView<const uint8_t, prand_size_>& prand,
         ArrayView<uint8_t, hash_size_> hash
     );
 
 private:
+
+#if defined(MBEDTLS_ECDH_C)
     void load_mpi(mbedtls_mpi& dest, const ArrayView<const uint8_t, lesc_key_size_>& src);
 
     void store_mpi(ArrayView<uint8_t, lesc_key_size_>& dest, const mbedtls_mpi& src);
+#endif
 
-    void swap_endian(uint8_t* buf, size_t len);
+    static void swap_endian(uint8_t* buf, size_t len);
 
+#if defined(MBEDTLS_ECDH_C)
     bool _initialized;
     mbedtls_entropy_context _entropy_context;
     mbedtls_ecp_group _group;
+#endif
+
 };
 
 } // nordic
 } // vendor
 } // pal
 } // ble
-
-#endif // defined(MBEDTLS_ECDH_C)
 
 #endif // NRF5X_CRYPTO_

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.cpp
@@ -32,6 +32,10 @@ using ble::pal::vendor::nordic::nRF5xSecurityManager;
 typedef nRF5xSecurityManager::resolving_list_entry_t resolving_list_entry_t;
 using ble::ArrayView;
 using ble::pal::advertising_peer_address_type_t;
+using ble::peer_address_type_t;
+
+typedef BLEProtocol::AddressType LegacyAddressType;
+typedef BLEProtocol::AddressType_t LegacyAddressType_t;
 
 namespace {
 
@@ -39,14 +43,16 @@ nRF5xSecurityManager& get_sm() {
     return nRF5xSecurityManager::get_security_manager();
 }
 
-void set_private_resolvable_address() {
+ble_error_t set_private_resolvable_address() {
     ble_gap_addr_t addr = { BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE };
-    sd_ble_gap_address_set(BLE_GAP_ADDR_CYCLE_MODE_AUTO, &addr);
+    uint32_t err = sd_ble_gap_address_set(BLE_GAP_ADDR_CYCLE_MODE_AUTO, &addr);
+    return err ? BLE_ERROR_UNSPECIFIED : BLE_ERROR_NONE;
 }
 
-void set_private_non_resolvable_address() {
+ble_error_t set_private_non_resolvable_address() {
     ble_gap_addr_t addr = { BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE };
-    sd_ble_gap_address_set(BLE_GAP_ADDR_CYCLE_MODE_AUTO, &addr);
+    uint32_t err = sd_ble_gap_address_set(BLE_GAP_ADDR_CYCLE_MODE_AUTO, &addr);
+    return err ? BLE_ERROR_UNSPECIFIED : BLE_ERROR_NONE;
 }
 
 bool is_advertising_non_connectable(const GapAdvertisingParams &params) {
@@ -59,29 +65,24 @@ bool is_advertising_non_connectable(const GapAdvertisingParams &params) {
     }
 }
 
-bool is_identity_address(BLEProtocol::AddressType_t address_type) {
-    switch (address_type) {
-        case BLEProtocol::AddressType::PUBLIC_IDENTITY:
-        case BLEProtocol::AddressType::RANDOM_STATIC_IDENTITY:
-            return true;
-        default:
-            return false;
-    }
+bool is_identity_address(peer_address_type_t address_type) {
+    return address_type == peer_address_type_t::PUBLIC_IDENTITY ||
+        address_type == peer_address_type_t::RANDOM_STATIC_IDENTITY;
 }
 
-BLEProtocol::AddressType_t convert_nordic_address(uint8_t address) {
+peer_address_type_t convert_nordic_address(uint8_t address) {
     if (address == BLE_GAP_ADDR_TYPE_PUBLIC) {
-        return BLEProtocol::AddressType::PUBLIC;
+        return peer_address_type_t::PUBLIC;
     } else {
-        return BLEProtocol::AddressType::RANDOM;
+        return peer_address_type_t::RANDOM;
     }
 }
 
-BLEProtocol::AddressType_t convert_identity_address(advertising_peer_address_type_t address) {
+peer_address_type_t convert_identity_address(advertising_peer_address_type_t address) {
     if (address == advertising_peer_address_type_t::PUBLIC_ADDRESS) {
-        return BLEProtocol::AddressType::PUBLIC_IDENTITY;
+        return peer_address_type_t::PUBLIC_IDENTITY;
     } else {
-        return BLEProtocol::AddressType::RANDOM_STATIC_IDENTITY;
+        return peer_address_type_t::RANDOM_STATIC_IDENTITY;
     }
 }
 
@@ -103,7 +104,7 @@ nRF5xGap::nRF5xGap() : Gap(),
     _privacy_enabled(false),
     _peripheral_privacy_configuration(default_peripheral_privacy_configuration),
     _central_privacy_configuration(default_central_privacy_configuration),
-    _non_private_type(BLEProtocol::AddressType::RANDOM)
+    _non_private_address_type(LegacyAddressType::RANDOM_STATIC)
 {
         m_connectionHandle = BLE_CONN_HANDLE_INVALID;
 }
@@ -259,12 +260,10 @@ ble_error_t nRF5xGap::startAdvertising(const GapAdvertisingParams &params)
     whitelist.addr_count = 0;
     whitelist.irk_count  = 0;
 
-    /* Add missing IRKs to whitelist from the bond table held by the SoftDevice */
-    if (advertisingPolicyMode != Gap::ADV_POLICY_IGNORE_WHITELIST) {
-        ble_error_t error = generateStackWhitelist(whitelist);
-        if (error != BLE_ERROR_NONE) {
-            return error;
-        }
+    whitelist.addr_count = whitelistAddressesSize;
+
+    for (uint32_t i = 0; i < whitelistAddressesSize; ++i) {
+        whitelistAddressPtrs[i] = &whitelistAddresses[i];
     }
 
     if (_privacy_enabled) {
@@ -295,14 +294,11 @@ ble_error_t nRF5xGap::startAdvertising(const GapAdvertisingParams &params)
     /* For NRF_SD_BLE_API_VERSION >= 3 nRF5xGap::setWhitelist setups the whitelist. */
 
     /* Start Advertising */
-
-
     adv_para.type        = params.getAdvertisingType();
     adv_para.p_peer_addr = NULL;                           // Undirected advertisement
     adv_para.fp          = advertisingPolicyMode;
     adv_para.interval    = params.getIntervalInADVUnits(); // advertising interval (in units of 0.625 ms)
     adv_para.timeout     = params.getTimeout();
-
 
     err = sd_ble_gap_adv_start(&adv_para);
     switch(err) {
@@ -319,7 +315,6 @@ ble_error_t nRF5xGap::startAdvertising(const GapAdvertisingParams &params)
 #if !defined(TARGET_MCU_NRF51_16K_S110) && !defined(TARGET_MCU_NRF51_32K_S110)
 ble_error_t nRF5xGap::startRadioScan(const GapScanningParams &scanningParams)
 {
-
     ble_gap_scan_params_t scanParams;
 
 #if  (NRF_SD_BLE_API_VERSION <= 2)
@@ -333,15 +328,26 @@ ble_error_t nRF5xGap::startRadioScan(const GapScanningParams &scanningParams)
     whitelist.addr_count = 0;
     whitelist.irk_count  = 0;
 
-    /* Add missing IRKs to whitelist from the bond table held by the SoftDevice */
-    if (scanningPolicyMode != Gap::SCAN_POLICY_IGNORE_WHITELIST) {
-        ble_error_t error = generateStackWhitelist(whitelist);
-        if (error != BLE_ERROR_NONE) {
-            return error;
-        }
+    whitelist.addr_count = whitelistAddressesSize;
+
+    for (uint32_t i = 0; i < whitelistAddressesSize; ++i) {
+        whitelistAddressPtrs[i] = &whitelistAddresses[i];
     }
 
-    // FIXME: fill the irk list once addresses are resolved by the softdevice.
+    if (_privacy_enabled) {
+        if (_central_privacy_configuration.resolution_strategy != CentralPrivacyConfiguration_t::DO_NOT_RESOLVE) {
+            ArrayView<resolving_list_entry_t> entries = get_sm().get_resolving_list();
+
+            size_t limit = std::min(
+                entries.size(), (size_t) YOTTA_CFG_IRK_TABLE_MAX_SIZE
+            );
+
+            for (size_t i = 0; i < limit; ++i) {
+                whitelistIrkPtrs[i] = (ble_gap_irk_t*) entries[i].peer_irk.data();
+            }
+            whitelist.irk_count = limit;
+        }
+    }
 
     scanParams.selective   = scanningPolicyMode;    /**< If 1, ignore unknown devices (non whitelisted). */
     scanParams.p_whitelist = &whitelist; /**< Pointer to whitelist, NULL if none is given. */
@@ -408,11 +414,59 @@ ble_error_t nRF5xGap::stopAdvertising(void)
     return BLE_ERROR_NONE;
 }
 
-ble_error_t nRF5xGap::connect(const Address_t             peerAddr,
-                              BLEProtocol::AddressType_t  peerAddrType,
-                              const ConnectionParams_t   *connectionParams,
-                              const GapScanningParams    *scanParamsIn)
-{
+ble_error_t nRF5xGap::connect(
+    const Address_t peerAddr,
+    peer_address_type_t peerAddrType,
+    const ConnectionParams_t *connectionParams,
+    const GapScanningParams *scanParamsIn
+) {
+    // NOTE: Nordic address type is an closer to LegacyAddressType: resolved
+    // address are treaded either as PUBLIC or RANDOM STATIC adresses.
+    // The idea is to get the conversion done here and call the legacy function.
+
+    LegacyAddressType_t legacy_address;
+
+    switch (peerAddrType.value()) {
+        case peer_address_type_t::PUBLIC:
+        case peer_address_type_t::PUBLIC_IDENTITY:
+            legacy_address = LegacyAddressType::PUBLIC;
+            break;
+        case peer_address_type_t::RANDOM_STATIC_IDENTITY:
+            legacy_address = LegacyAddressType::RANDOM_STATIC;
+            break;
+        case peer_address_type_t::RANDOM: {
+            RandomAddressType_t random_address_type(RandomAddressType_t::STATIC);
+            ble_error_t err = getRandomAddressType(peerAddr, &random_address_type);
+            if (err) {
+                return err;
+            }
+            switch (random_address_type.value()) {
+                case RandomAddressType_t::STATIC:
+                    legacy_address = LegacyAddressType::RANDOM_STATIC;
+                    break;
+                case RandomAddressType_t::NON_RESOLVABLE_PRIVATE:
+                    legacy_address = LegacyAddressType::RANDOM_PRIVATE_NON_RESOLVABLE;
+                    break;
+                case RandomAddressType_t::RESOLVABLE_PRIVATE:
+                    legacy_address = LegacyAddressType::RANDOM_PRIVATE_RESOLVABLE;
+                    break;
+                default:
+                    return BLE_ERROR_UNSPECIFIED;
+            }
+        }   break;
+        default:
+            return BLE_ERROR_INVALID_PARAM;
+    }
+
+    return connect(peerAddr, legacy_address, connectionParams, scanParamsIn);
+}
+
+ble_error_t nRF5xGap::connect(
+    const Address_t peerAddr,
+    LegacyAddressType_t peerAddrType,
+    const ConnectionParams_t *connectionParams,
+    const GapScanningParams *scanParamsIn
+) {
     ble_gap_addr_t addr;
     ble_gap_addr_t* addr_ptr = &addr;
     addr.addr_type = peerAddrType;
@@ -444,40 +498,21 @@ ble_error_t nRF5xGap::connect(const Address_t             peerAddr,
     whitelist.addr_count = 0;
     whitelist.irk_count  = 0;
 
-    /* Add missing IRKs to whitelist from the bond table held by the SoftDevice */
-    if (scanningPolicyMode != Gap::SCAN_POLICY_IGNORE_WHITELIST) {
-        ble_error_t error = generateStackWhitelist(whitelist);
-        if (error != BLE_ERROR_NONE) {
-            return error;
-        }
-    }
     scanParams.selective   = scanningPolicyMode;    /**< If 1, ignore unknown devices (non whitelisted). */
     scanParams.p_whitelist = &whitelist; /**< Pointer to whitelist, NULL if none is given. */
 
     if (_privacy_enabled) {
-        // configure the "whitelist" with the IRK associated with the identity
-        // address in input.
-        if (is_identity_address(peerAddrType)) {
+        if (_central_privacy_configuration.resolution_strategy != CentralPrivacyConfiguration_t::DO_NOT_RESOLVE) {
             ArrayView<resolving_list_entry_t> entries = get_sm().get_resolving_list();
 
-            size_t i;
-            for (i = 0; i < entries.size(); ++i) {
-                const ble::address_t& entry_address = entries[i].peer_identity_address;
+            size_t limit = std::min(
+                entries.size(), (size_t) YOTTA_CFG_IRK_TABLE_MAX_SIZE
+            );
 
-                // entry found; fill the whitelist and invalidate addr_ptr
-                if (memcmp(entry_address.data(), peerAddr, entry_address.size_) == 0) {
-                    whitelist.pp_irks[0] = (ble_gap_irk_t*) entries[i].peer_irk.data();
-                    whitelist.irk_count = 1;
-                    scanParams.selective = 1;
-                    addr_ptr = NULL;
-                    break;
-                }
+            for (size_t i = 0; i < limit; ++i) {
+                whitelistIrkPtrs[i] = (ble_gap_irk_t*) entries[i].peer_irk.data();
             }
-
-            // Occur only if the address in input hasn't been resolved.
-            if (i == entries.size()) {
-                return BLE_ERROR_INVALID_PARAM;
-            }
+            whitelist.irk_count = limit;
         }
 
         set_private_resolvable_address();
@@ -666,11 +701,11 @@ uint16_t nRF5xGap::getConnectionHandle(void)
     @endcode
 */
 /**************************************************************************/
-ble_error_t nRF5xGap::setAddress(AddressType_t type, const Address_t address)
+ble_error_t nRF5xGap::setAddress(LegacyAddressType_t type, const Address_t address)
 {
-    using BLEProtocol::AddressType;
-
-    if (type != AddressType::PUBLIC || type != AddressType::RANDOM_STATIC) {
+    if (type != LegacyAddressType::PUBLIC &&
+        type != LegacyAddressType::RANDOM_STATIC
+    ) {
         return BLE_ERROR_INVALID_PARAM;
     }
 
@@ -680,30 +715,41 @@ ble_error_t nRF5xGap::setAddress(AddressType_t type, const Address_t address)
 
     ble_gap_addr_t dev_addr;
     memcpy(dev_addr.addr, address, ADDR_LEN);
-    if (type == AddressType::PUBLIC) {
+    if (type == LegacyAddressType::PUBLIC) {
         dev_addr.addr_type = BLE_GAP_ADDR_TYPE_PUBLIC;
     } else {
         dev_addr.addr_type = BLE_GAP_ADDR_TYPE_RANDOM_STATIC;
     }
 
 #if  (NRF_SD_BLE_API_VERSION <= 2)
-    ASSERT_INT(ERROR_NONE, sd_ble_gap_address_set(BLE_GAP_ADDR_CYCLE_MODE_NONE, &dev_addr), BLE_ERROR_PARAM_OUT_OF_RANGE);
+    uint32_t err = sd_ble_gap_address_set(BLE_GAP_ADDR_CYCLE_MODE_NONE, &dev_addr);
 #else
-    // FIXME is there any reason to use the pm ?
-    ble_gap_privacy_params_t privacy_params = {0};
-    privacy_params.privacy_mode = BLE_GAP_PRIVACY_MODE_OFF;
-
-    ASSERT_INT(ERROR_NONE, pm_id_addr_set(&dev_addr), BLE_ERROR_PARAM_OUT_OF_RANGE);
-    ASSERT_INT(ERROR_NONE, pm_privacy_set(&privacy_params), BLE_ERROR_PARAM_OUT_OF_RANGE);
+    uint32_t err = sd_ble_gap_addr_set(&dev_addr);
 #endif
 
-    return BLE_ERROR_NONE;
+    switch (err) {
+        case NRF_SUCCESS:
+            return BLE_ERROR_NONE;
+        case NRF_ERROR_INVALID_ADDR:
+            return BLE_ERROR_INVALID_PARAM;
+        case BLE_ERROR_GAP_INVALID_BLE_ADDR:
+            return BLE_ERROR_PARAM_OUT_OF_RANGE;
+        case NRF_ERROR_BUSY:
+            return BLE_STACK_BUSY;
+        case NRF_ERROR_INVALID_STATE:
+            return BLE_ERROR_INVALID_STATE;
+        default:
+            return BLE_ERROR_UNSPECIFIED;
+    }
 }
 
 ble_error_t nRF5xGap::getAddress(AddressType_t *typeP, Address_t address)
 {
-    ble_gap_addr_t dev_addr;
+    if (typeP == NULL || address == NULL) {
+        return BLE_ERROR_INVALID_PARAM;
+    }
 
+    ble_gap_addr_t dev_addr;
 #if  (NRF_SD_BLE_API_VERSION <= 2)
     if (sd_ble_gap_address_get(&dev_addr) != NRF_SUCCESS) {
 #else
@@ -712,17 +758,20 @@ ble_error_t nRF5xGap::getAddress(AddressType_t *typeP, Address_t address)
         return BLE_ERROR_PARAM_OUT_OF_RANGE;
     }
 
-    if (typeP != NULL) {
-        if (dev_addr.addr_type == BLE_GAP_ADDR_TYPE_PUBLIC){
-            *typeP = BLEProtocol::AddressType::PUBLIC;
-        } else {
-            *typeP = BLEProtocol::AddressType::RANDOM;
-        }
+    switch (dev_addr.addr_type) {
+        case BLE_GAP_ADDR_TYPE_PUBLIC:
+            *typeP = LegacyAddressType::PUBLIC;
+            break;
+
+        case BLE_GAP_ADDR_TYPE_RANDOM_STATIC:
+            *typeP = LegacyAddressType::RANDOM_STATIC;
+            break;
+
+        default:
+            return BLE_ERROR_INVALID_STATE;
     }
 
-    if (address != NULL) {
-        memcpy(address, dev_addr.addr, ADDR_LEN);
-    }
+    memcpy(address, dev_addr.addr, ADDR_LEN);
 
     return BLE_ERROR_NONE;
 }
@@ -849,9 +898,7 @@ ble_error_t nRF5xGap::getWhitelist(Gap::Whitelist_t &whitelistOut) const
     uint32_t i;
     for (i = 0; i < whitelistAddressesSize && i < whitelistOut.capacity; ++i) {
         memcpy( &whitelistOut.addresses[i].address, &whitelistAddresses[i].addr, sizeof(whitelistOut.addresses[0].address));
-        whitelistOut.addresses[i].type = static_cast<BLEProtocol::AddressType_t> (whitelistAddresses[i].addr_type);
-
-
+        whitelistOut.addresses[i].type = static_cast<LegacyAddressType_t> (whitelistAddresses[i].addr_type);
     }
     whitelistOut.size = i;
 
@@ -896,7 +943,9 @@ ble_error_t nRF5xGap::setWhitelist(const Gap::Whitelist_t &whitelistIn)
 
     /* Test for invalid parameters before we change the internal state */
     for (uint32_t i = 0; i < whitelistIn.size; ++i) {
-        if (whitelistIn.addresses[i].type == BLEProtocol::AddressType::RANDOM_PRIVATE_NON_RESOLVABLE) {
+        if (whitelistIn.addresses[i].type == LegacyAddressType::RANDOM_PRIVATE_NON_RESOLVABLE ||
+            whitelistIn.addresses[i].type == LegacyAddressType::RANDOM_PRIVATE_RESOLVABLE
+        ) {
             /* This is not allowed because it is completely meaningless */
             return BLE_ERROR_INVALID_PARAM;
         }
@@ -1052,24 +1101,38 @@ Gap::InitiatorPolicyMode_t nRF5xGap::getInitiatorPolicyMode(void) const
     return Gap::INIT_POLICY_IGNORE_WHITELIST;
 }
 
-ble_error_t nRF5xGap::enablePrivacy(bool enable)
+ble_error_t nRF5xGap::enablePrivacy(bool enable_privacy)
 {
-    if (enable == _privacy_enabled) {
+    if (enable_privacy == _privacy_enabled) {
         return BLE_ERROR_NONE;
     }
 
     ble_error_t err = BLE_ERROR_UNSPECIFIED;
-    if (enable == false) {
-        err = setAddress(_non_private_type, _non_private_address);
+    if (enable_privacy == false) {
+        err = setAddress(_non_private_address_type, _non_private_address);
     } else {
-        err = getAddress(&_non_private_type, _non_private_address);
+        err = getAddress(&_non_private_address_type, _non_private_address);
     }
 
     if (err) {
         return err;
     }
 
-    _privacy_enabled = enable;
+#if (NRF_SD_BLE_API_VERSION > 2)
+    ble_gap_privacy_params_t privacy_config = { 0 };
+    if (sd_ble_gap_privacy_get(&privacy_config)) {
+        return BLE_ERROR_UNSPECIFIED;
+    }
+
+    privacy_config.privacy_mode = enable_privacy ?
+        BLE_GAP_PRIVACY_MODE_DEVICE_PRIVACY :
+        BLE_GAP_PRIVACY_MODE_OFF;
+    if (sd_ble_gap_privacy_set(&privacy_config)) {
+        return BLE_ERROR_UNSPECIFIED;
+    }
+#endif
+
+    _privacy_enabled = enable_privacy;
     return BLE_ERROR_NONE;
 }
 
@@ -1101,116 +1164,6 @@ ble_error_t nRF5xGap::getCentralPrivacyConfiguration(
     return BLE_ERROR_NONE;
 }
 
-#if  (NRF_SD_BLE_API_VERSION <= 2)
-/**************************************************************************/
-/*!
-    @brief  Helper function used to populate the ble_gap_whitelist_t that
-            will be used by the SoftDevice for filtering requests.
-    @returns    \ref ble_error_t
-    @retval     BLE_ERROR_NONE
-                Everything executed properly
-    @retval     BLE_ERROR_INVALID_STATE
-                The internal stack was not initialized correctly.
-    @note  Both the SecurityManager and Gap must initialize correctly for
-           this function to succeed.
-    @note  This function is needed because for the BLE API the whitelist
-           is just a collection of keys, but for the stack it also includes
-           the IRK table.
-    @section EXAMPLE
-    @code
-    @endcode
-*/
-/**************************************************************************/
-ble_error_t nRF5xGap::generateStackWhitelist(ble_gap_whitelist_t &whitelist)
-{
-    return BLE_ERROR_NOT_IMPLEMENTED;
-}
-#endif
-
-#if  (NRF_SD_BLE_API_VERSION >= 3)
-
-/**
- * Function for preparing settings of the whitelist feature and the identity-resolving feature (privacy) for the SoftDevice.
- *
- * Gap::setWhitelist provides the base for preparation of these settings.
- * This function matches resolvable addresses (passed by Gap::setWhitelist) to IRK data in bonds table.
- * Therefore resolvable addresses instead of being passed to the whitelist (intended to be passed to the Softdevice)
- * are passed to the identities list (intended to be passed to the Softdevice).
- *
- * @param[out] gapAdrHelper Reference to the struct for storing settings.
- */
-
-ble_error_t nRF5xGap::getStackWhiteIdentityList(GapWhiteAndIdentityList_t &gapAdrHelper)
-{
-    BLE_ERROR_NOT_IMPLEMENTED;
-}
-
-ble_error_t nRF5xGap::applyWhiteIdentityList(GapWhiteAndIdentityList_t &gapAdrHelper)
-{
-    uint32_t retc;
-
-    if (gapAdrHelper.identities_cnt == 0) {
-        retc = sd_ble_gap_device_identities_set(NULL, NULL, 0);
-    } else {
-    	ble_gap_id_key_t * pp_identities[YOTTA_CFG_IRK_TABLE_MAX_SIZE];
-
-        for (uint32_t i = 0; i < gapAdrHelper.identities_cnt; ++i)
-        {
-        	pp_identities[i] = &gapAdrHelper.identities[i];
-        }
-
-        retc = sd_ble_gap_device_identities_set(pp_identities, NULL /* Don't use local IRKs*/,gapAdrHelper.identities_cnt);
-    }
-
-    if (retc == NRF_SUCCESS) {
-        if (gapAdrHelper.addrs_cnt == 0) {
-            retc = sd_ble_gap_whitelist_set(NULL, 0);
-        } else {
-        	ble_gap_addr_t * pp_addrs[YOTTA_CFG_IRK_TABLE_MAX_SIZE];
-
-            for (uint32_t i = 0; i < gapAdrHelper.addrs_cnt; ++i)
-            {
-            	pp_addrs[i] = &gapAdrHelper.addrs[i];
-            }
-
-            retc = sd_ble_gap_whitelist_set(pp_addrs, gapAdrHelper.addrs_cnt);
-        }
-    }
-
-    switch(retc) {
-        case NRF_SUCCESS:
-            return BLE_ERROR_NONE;
-
-        case BLE_ERROR_GAP_WHITELIST_IN_USE: //The whitelist is in use by a BLE role and cannot be set or cleared.
-        case BLE_ERROR_GAP_DEVICE_IDENTITIES_IN_USE: //The device identity list is in use and cannot be set or cleared.
-            return BLE_ERROR_ALREADY_INITIALIZED;
-
-        case NRF_ERROR_INVALID_ADDR:
-        case BLE_ERROR_GAP_INVALID_BLE_ADDR: //Invalid address type is supplied.
-        case NRF_ERROR_DATA_SIZE:
-        case BLE_ERROR_GAP_DEVICE_IDENTITIES_DUPLICATE: //The device identity list contains multiple entries with the same identity address.
-            return BLE_ERROR_INVALID_PARAM;
-
-        default:
-            return BLE_ERROR_UNSPECIFIED;
-    }
-}
-
-ble_error_t nRF5xGap::updateWhiteAndIdentityListInStack()
-{
-    GapWhiteAndIdentityList_t whiteAndIdentityList;
-    uint32_t                  err;
-
-    err = getStackWhiteIdentityList(whiteAndIdentityList);
-
-    if (err != BLE_ERROR_NONE) {
-        return (ble_error_t)err;
-    }
-
-    return applyWhiteIdentityList(whiteAndIdentityList);
-}
-#endif
-
 void nRF5xGap::set_connection_event_handler(
     ConnectionEventMonitor::EventHandler* connection_event_handler
 ) {
@@ -1241,24 +1194,26 @@ void nRF5xGap::on_connection(Gap::Handle_t handle, const ble_gap_evt_connected_t
     setConnectionHandle(handle);
 
     // deal with own address
-    AddressType_t own_addr_type;
+    LegacyAddressType_t own_addr_type;
     Address_t own_address;
     const uint8_t* own_resolvable_address = NULL;
 
 #if  (NRF_SD_BLE_API_VERSION <= 2)
-    if (evt.own_addr.addr_type == BLE_GAP_ADDR_TYPE_PUBLIC) {
-        own_addr_type = AddressType::PUBLIC;
+    if (_privacy_enabled) {
+        own_addr_type = LegacyAddressType::RANDOM_PRIVATE_RESOLVABLE;
     } else {
-        own_addr_type = AddressType::RANDOM;
+        if (evt.own_addr.addr_type == BLE_GAP_ADDR_TYPE_PUBLIC) {
+            own_addr_type = LegacyAddressType::PUBLIC;
+        } else {
+            own_addr_type = LegacyAddressType::RANDOM_STATIC;
+        }
     }
+
+    // FIXME: is it the resolvable address or the identity address ?
     memcpy(own_address, evt.own_addr.addr, sizeof(own_address));
 #else
     gap.getAddress(&addr_type, own_address);
 #endif
-
-    if (_privacy_enabled) {
-        own_resolvable_address = own_address;
-    }
 
     // deal with the peer address: If privacy is enabled then the softdevice
     // indicates if the address has been resolved or not. If the address has
@@ -1266,11 +1221,17 @@ void nRF5xGap::on_connection(Gap::Handle_t handle, const ble_gap_evt_connected_t
     // Depending on the privacy chosen by the application, connection request
     // from privacy enabled peers may trigger a disconnection, the pairing procedure
     // or the authentication procedure.
-    AddressType_t peer_addr_type;
+    peer_address_type_t peer_addr_type(peer_address_type_t::PUBLIC);
     const uint8_t* peer_address;
     const uint8_t* peer_resolvable_address;
 
-    if (evt.irk_match) {
+#if (NRF_SD_BLE_API_VERSION <= 2)
+    bool private_peer_known = evt.irk_match;
+#else
+    bool private_peer_known = evt.peer_addr.addr_id_peer;
+#endif
+
+    if (private_peer_known) {
         const resolving_list_entry_t* entry = get_sm().resolve_address(
             evt.peer_addr.addr
         );
@@ -1311,14 +1272,14 @@ void nRF5xGap::on_connection(Gap::Handle_t handle, const ble_gap_evt_connected_t
     }
 
     // Apply authentication strategy before application notification
-    if (!evt.irk_match &&
+    if (!private_peer_known &&
         _privacy_enabled &&
         evt.role == BLE_GAP_ROLE_PERIPH &&
         evt.peer_addr.addr_type == BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE
     ) {
         switch (_peripheral_privacy_configuration.resolution_strategy) {
             case PeripheralPrivacyConfiguration_t::PERFORM_PAIRING_PROCEDURE:
-                nRF5xn::Instance(BLE::DEFAULT_INSTANCE).getSecurityManager().requestPairing(handle);
+                nRF5xn::Instance(BLE::DEFAULT_INSTANCE).getSecurityManager().requestAuthentication(handle);
                 break;
 
             case PeripheralPrivacyConfiguration_t::PERFORM_AUTHENTICATION_PROCEDURE:
@@ -1344,9 +1305,7 @@ void nRF5xGap::on_connection(Gap::Handle_t handle, const ble_gap_evt_connected_t
 }
 
 void nRF5xGap::on_advertising_packet(const ble_gap_evt_adv_report_t &evt) {
-    using BLEProtocol::AddressType;
-
-    AddressType_t peer_addr_type;
+    peer_address_type_t peer_addr_type(peer_address_type_t::PUBLIC);
     const uint8_t* peer_address = evt.peer_addr.addr;
 
     if (_privacy_enabled &&

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.cpp
@@ -1352,7 +1352,9 @@ void nRF5xGap::on_advertising_packet(const ble_gap_evt_adv_report_t &evt) {
         if (entry) {
             peer_address = entry->peer_identity_address.data();
             peer_addr_type = convert_identity_address(entry->peer_identity_address_type);
-        } else if (_central_privacy_configuration.resolution_strategy != CentralPrivacyConfiguration_t::RESOLVE_AND_FORWARD) {
+        } else if (_central_privacy_configuration.resolution_strategy == CentralPrivacyConfiguration_t::RESOLVE_AND_FORWARD ||
+            get_sm().get_resolving_list().size() == 0
+        ) {
             peer_addr_type = convert_nordic_address(evt.peer_addr.addr_type);
         } else {
             // filter out the packet.

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.cpp
@@ -1248,6 +1248,16 @@ void nRF5xGap::on_connection(Gap::Handle_t handle, const ble_gap_evt_connected_t
 
 #if (NRF_SD_BLE_API_VERSION <= 2)
     bool private_peer_known = evt.irk_match;
+
+    // thanks to softdevice consistencies; addresses are not resolved on the
+    // peripheral side ...
+    if (_privacy_enabled &&
+        evt.role == BLE_GAP_ROLE_PERIPH &&
+        _peripheral_privacy_configuration.resolution_strategy != PeripheralPrivacyConfiguration_t::DO_NOT_RESOLVE &&
+        get_sm().resolve_address(evt.peer_addr.addr) != NULL
+    ) {
+        private_peer_known = true;
+    }
 #else
     bool private_peer_known = evt.peer_addr.addr_id_peer;
 #endif

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.h
@@ -78,6 +78,7 @@ public:
 
     virtual ble_error_t startAdvertising(const GapAdvertisingParams &);
     virtual ble_error_t stopAdvertising(void);
+    virtual ble_error_t connect(const Address_t, ble::peer_address_type_t peerAddrType, const ConnectionParams_t *connectionParams, const GapScanningParams *scanParams);
     virtual ble_error_t connect(const Address_t, BLEProtocol::AddressType_t peerAddrType, const ConnectionParams_t *connectionParams, const GapScanningParams *scanParams);
     virtual ble_error_t disconnect(Handle_t connectionHandle, DisconnectionReason_t reason);
     virtual ble_error_t disconnect(DisconnectionReason_t reason);
@@ -158,39 +159,6 @@ private:
     /* Internal representation of a whitelist */
     uint8_t         whitelistAddressesSize;
     ble_gap_addr_t  whitelistAddresses[YOTTA_CFG_WHITELIST_MAX_SIZE];
-
-#if  (NRF_SD_BLE_API_VERSION <= 2)
-    /*
-     * An internal function used to populate the ble_gap_whitelist_t that will be used by
-     * the SoftDevice for filtering requests. This function is needed because for the BLE
-     * API the whitelist is just a collection of keys, but for the stack it also includes
-     * the IRK table.
-     */
-    ble_error_t generateStackWhitelist(ble_gap_whitelist_t &whitelist);
-#endif
-    
-#if  (NRF_SD_BLE_API_VERSION >= 3)
-    /* internal type for passing a whitelist and a identities list. */
-    typedef struct
-    {
-        ble_gap_addr_t addrs[YOTTA_CFG_WHITELIST_MAX_SIZE];
-        uint32_t addrs_cnt;
-        
-        ble_gap_id_key_t identities[YOTTA_CFG_IRK_TABLE_MAX_SIZE];
-        uint32_t identities_cnt;
-    } GapWhiteAndIdentityList_t;
-    
-    /* Function for preparing setting of the whitelist feature and the identity-resolving feature (privacy).*/
-    ble_error_t getStackWhiteIdentityList(GapWhiteAndIdentityList_t &whiteAndIdentityList);
-
-    /* Function for applying setting of the whitelist feature and identity-resolving feature (privacy).*/
-    ble_error_t applyWhiteIdentityList(GapWhiteAndIdentityList_t &whiteAndIdentityList);
-
-    /* Function for introducing whitelist feature and the identity-resolving feature setting into SoftDevice.
-     *
-     * This function incorporates getStackWhiteIdentityList and applyWhiteIdentityList together. */
-    ble_error_t updateWhiteAndIdentityListInStack(void);
-#endif
 
 private:
     bool    radioNotificationCallbackParam; /* parameter to be passed into the Timeout-generated radio notification callback. */
@@ -303,7 +271,7 @@ private:
     bool _privacy_enabled;
     PeripheralPrivacyConfiguration_t _peripheral_privacy_configuration;
     CentralPrivacyConfiguration_t _central_privacy_configuration;
-    AddressType_t _non_private_type;
+    AddressType_t _non_private_address_type;
     Address_t _non_private_address;
 
     /*

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.h
@@ -80,6 +80,7 @@ public:
     virtual ble_error_t stopAdvertising(void);
     virtual ble_error_t connect(const Address_t, ble::peer_address_type_t peerAddrType, const ConnectionParams_t *connectionParams, const GapScanningParams *scanParams);
     virtual ble_error_t connect(const Address_t, BLEProtocol::AddressType_t peerAddrType, const ConnectionParams_t *connectionParams, const GapScanningParams *scanParams);
+            ble_error_t connect(const Address_t, BLEProtocol::AddressType_t peerAddrType, const ConnectionParams_t *connectionParams, const GapScanningParams *scanParams, bool identity);
     virtual ble_error_t disconnect(Handle_t connectionHandle, DisconnectionReason_t reason);
     virtual ble_error_t disconnect(DisconnectionReason_t reason);
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xPalSecurityManager.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xPalSecurityManager.cpp
@@ -373,7 +373,7 @@ ble_error_t nRF5xSecurityManager::cancel_pairing(
 ble_error_t nRF5xSecurityManager::get_secure_connections_support(
     bool &enabled
 ) {
-    enabled = true;
+    enabled = false;
     return BLE_ERROR_NONE;
 }
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xPalSecurityManager.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xPalSecurityManager.cpp
@@ -213,7 +213,6 @@ nRF5xSecurityManager::get_resolving_list() {
 
 const nRF5xSecurityManager::resolving_list_entry_t*
 nRF5xSecurityManager::resolve_address(const address_t& resolvable_address) {
-#if defined(MBEDTLS_ECDH_C)
     typedef byte_array_t<CryptoToolbox::hash_size_> hash_t;
 
     for (size_t i = 0; i < resolving_list_entry_count; ++i) {
@@ -222,7 +221,7 @@ nRF5xSecurityManager::resolve_address(const address_t& resolvable_address) {
 
         // Compute the hash part from the random address part when the irk of
         // the entry is used
-        _crypto.ah(
+        CryptoToolbox::ah(
             make_const_ArrayView<CryptoToolbox::irk_size_>(entry.peer_irk),
             make_const_ArrayView<CryptoToolbox::prand_size_>(
                 resolvable_address.data() + CryptoToolbox::hash_size_
@@ -237,7 +236,7 @@ nRF5xSecurityManager::resolve_address(const address_t& resolvable_address) {
             return &entry;
         }
     }
-#endif
+
     return NULL;
 }
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xGap.cpp
@@ -44,12 +44,8 @@ nRF5xSecurityManager& get_sm() {
 
 ble_error_t set_private_resolvable_address() {
 #if (NRF_SD_BLE_API_VERSION <= 2)
-    ble_gap_addr_t addr = {
-        BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE
-    };
-
-    sd_ble_gap_address_set(BLE_GAP_ADDR_CYCLE_MODE_AUTO, &addr);
-    return BLE_ERROR_NONE;
+    ble_gap_addr_t addr = { BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE };
+    uint32_t err = sd_ble_gap_address_set(BLE_GAP_ADDR_CYCLE_MODE_AUTO, &addr);
 #else
     ble_gap_privacy_params_t privacy_config = { 0 };
     uint32_t err = sd_ble_gap_privacy_get(&privacy_config);
@@ -59,14 +55,14 @@ ble_error_t set_private_resolvable_address() {
 
     privacy_config.private_addr_type = BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE;
     err = sd_ble_gap_privacy_set(&privacy_config);
-    return err ? BLE_ERROR_UNSPECIFIED : BLE_ERROR_NONE;
 #endif
+    return err ? BLE_ERROR_UNSPECIFIED : BLE_ERROR_NONE;
 }
 
 ble_error_t set_private_non_resolvable_address() {
 #if (NRF_SD_BLE_API_VERSION <= 2)
     ble_gap_addr_t addr = { BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE };
-    sd_ble_gap_address_set(BLE_GAP_ADDR_CYCLE_MODE_AUTO, &addr);
+    uint32_t err = sd_ble_gap_address_set(BLE_GAP_ADDR_CYCLE_MODE_AUTO, &addr);
 #else
     ble_gap_privacy_params_t privacy_config = { 0 };
     uint32_t err = sd_ble_gap_privacy_get(&privacy_config);
@@ -76,8 +72,8 @@ ble_error_t set_private_non_resolvable_address() {
 
     privacy_config.private_addr_type = BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE;
     err = sd_ble_gap_privacy_set(&privacy_config);
-    return err ? BLE_ERROR_UNSPECIFIED : BLE_ERROR_NONE;
 #endif
+    return err ? BLE_ERROR_UNSPECIFIED : BLE_ERROR_NONE;
 }
 
 bool is_advertising_non_connectable(const GapAdvertisingParams &params) {

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xGap.cpp
@@ -1393,8 +1393,7 @@ void nRF5xGap::on_connection(Gap::Handle_t handle, const ble_gap_evt_connected_t
             peer_address,
             own_addr_type,
             own_address.data(),
-            reinterpret_cast<const ConnectionParams_t *>(&(evt.conn_params)),
-            peer_resolvable_address
+            reinterpret_cast<const ConnectionParams_t *>(&(evt.conn_params))
         );
     }
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xGap.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xGap.h
@@ -86,6 +86,7 @@ public:
 
     virtual ble_error_t startAdvertising(const GapAdvertisingParams &);
     virtual ble_error_t stopAdvertising(void);
+    virtual ble_error_t connect(const Address_t, ble::peer_address_type_t peerAddrType, const ConnectionParams_t *connectionParams, const GapScanningParams *scanParams);
     virtual ble_error_t connect(const Address_t, BLEProtocol::AddressType_t peerAddrType, const ConnectionParams_t *connectionParams, const GapScanningParams *scanParams);
     virtual ble_error_t disconnect(Handle_t connectionHandle, DisconnectionReason_t reason);
     virtual ble_error_t disconnect(DisconnectionReason_t reason);


### PR DESCRIPTION
### Description

This PR revert the additions made for the privacy change to BLEProtocol::AddressType in favor of a new type. The function connect as well as the advertising report and connection report have been modified accordingly.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

