### PR TITLE
BLE: Fix wrong macro name for IAR

### DIFF
--- a/features/FEATURE_BLE/source/BLE.cpp
+++ b/features/FEATURE_BLE/source/BLE.cpp
@@ -50,7 +50,7 @@
 #define BLE_DEPRECATED_API_USE_END \
         _Pragma("pop")
 #else
-#define BLE_DEPRECATED_API_USE_BEGIN
+#define BLE_DEPRECATED_API_USE_END
 #endif
 
 static const char* error_strings[] = {


### PR DESCRIPTION
### Description

Fix a wrong macro name affecting BLE targets compiling with IAR.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

